### PR TITLE
fix: Correct placement and styling of branding on index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,10 @@
 </head>
 <body class="min-h-screen flex items-center justify-center p-4 bg-cover bg-center" style="background-image: url('/index.jpg');">
     <main class="glass-container text-white p-4 sm:p-8 w-full max-w-7xl mx-auto text-center">
+        <div class="flex justify-center items-center gap-4 mb-8">
+            <div class="flex items-center justify-center w-16 h-16 bg-white/20 backdrop-blur-sm border border-white/30 rounded-2xl text-white font-bold text-2xl shadow-lg">DB</div>
+            <h1 class="text-4xl font-bold text-white">Deriv Bot Store</h1>
+        </div>
         <!-- Slider main container -->
         <div class="swiper w-full">
             <!-- Additional required wrapper -->
@@ -62,10 +66,7 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5V6a3.75 3.75 0 1 0-7.5 0v4.5m11.356-1.993 1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 0 1-1.12-1.243l1.264-12A1.125 1.125 0 0 1 5.513 7.5h12.974c.576 0 1.059.435 1.119 1.007ZM8.625 10.5a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm7.5 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
                             </svg>
                         </div>
-                        <div class="flex justify-center items-center gap-4 mb-4">
-                            <h1 class="text-2xl font-bold text-white">Deriv Bot Store</h1>
-                            <div class="flex items-center justify-center w-12 h-12 bg-white rounded-xl text-green-600 font-bold text-xl shadow-md">DB</div>
-                        </div>
+                        <h3 class="text-lg font-semibold text-center mb-4">Trading Automations Store</h3>
                         <ul class="text-sm space-y-3 text-left">
                             <li class="flex items-center">
                                 <svg class="w-6 h-6 mr-2 text-green-400" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" stroke="currentColor"><path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>


### PR DESCRIPTION
This commit corrects the previous implementation for adding branding to the `index.html` page.

Corrections include:
- Moving the branding from a swiper card to a static header at the top of the main content area.
- Styling the "DB" icon to match the page's glassmorphism theme.
- Placing the "DB" icon before the "Deriv Bot Store" text, as requested by the user.