### PR TITLE
fix: Reset image previews after form submission

### DIFF
--- a/public/virus.html
+++ b/public/virus.html
@@ -1075,6 +1075,9 @@
           // No need for an additional global saveData() here as /api/add-bot already updated DB and server cache.
           renderBots();
           document.getElementById('product-form').reset();
+          const addPreview = document.getElementById('img-preview');
+          addPreview.src = '';
+          addPreview.classList.add('hidden');
           if (window.descQuill) {
             window.descQuill.setText(''); // Clear Quill editor
           }
@@ -1199,6 +1202,9 @@
     document.getElementById('edit-modal').classList.add('hidden');
     document.body.classList.remove('modal-active');
     document.getElementById('edit-form').reset();
+    const editPreview = document.getElementById('edit-img-preview');
+    editPreview.src = '';
+    editPreview.classList.add('hidden');
   }
 
   document.getElementById('edit-form').addEventListener('submit', async e => {


### PR DESCRIPTION
This commit fixes a UI bug where the image previews in the 'Add Bot' and 'Edit Bot' forms were not being properly reset after a successful submission or cancellation.

- In the 'Add Bot' form, the success handler now explicitly clears the `src` attribute of the preview `<img>` tag and adds the `hidden` class.
- The `closeEditModal` function, which is used for both successful edits and cancellations, has been updated to also clear the `src` and hide the preview `<img>` tag in the 'Edit Bot' modal.